### PR TITLE
Tainted Analysis encompassing arrays

### DIFF
--- a/src/main/java/br/unb/cic/analysis/df/TaintedAnalysis.java
+++ b/src/main/java/br/unb/cic/analysis/df/TaintedAnalysis.java
@@ -1,10 +1,13 @@
 package br.unb.cic.analysis.df;
 
 import soot.*;
+import soot.jimple.internal.JArrayRef;
 import soot.toolkits.scalar.ArraySparseSet;
 import soot.toolkits.scalar.FlowSet;
 
 import br.unb.cic.analysis.AbstractMergeConflictDefinition;
+
+import java.util.List;
 
 public class TaintedAnalysis extends ReachDefinitionAnalysis {
 
@@ -26,11 +29,17 @@ public class TaintedAnalysis extends ReachDefinitionAnalysis {
     protected FlowSet<DataFlowAbstraction> gen(Unit u, FlowSet<DataFlowAbstraction> in) {
         FlowSet<DataFlowAbstraction> res = new ArraySparseSet<>();
         if (isSourceStatement(u)) {
+            List<ValueBox> aux = u.getDefBoxes();
             for (ValueBox v : u.getDefBoxes()) {
                 if (v.getValue() instanceof Local)
                     res.add(new DataFlowAbstraction((Local) v.getValue(), findSourceStatement(u)));
+                else if (v.getValue() instanceof JArrayRef) {
+                    JArrayRef ref = (JArrayRef) v.getValue();
+                    res.add(new DataFlowAbstraction((Local) ref.getBaseBox().getValue(), findSourceStatement(u)));
+                }
             }
         } else if (u.getDefBoxes().size() > 0) {
+            List<ValueBox> aux = u.getUseBoxes();   //delete after DEBUG
             u.getUseBoxes().stream().filter(v -> v.getValue() instanceof Local).forEach(v -> {
                 Local local = (Local) v.getValue();
                 in.forEach(sourceDefs -> {

--- a/src/test/java/br/unb/cic/analysis/df/ArrayTaintedAnalysisOneConflictTest.java
+++ b/src/test/java/br/unb/cic/analysis/df/ArrayTaintedAnalysisOneConflictTest.java
@@ -26,8 +26,8 @@ public class ArrayTaintedAnalysisOneConflictTest {
             protected Map<String, List<Integer>> sourceDefinitions() {
                 Map<String, List<Integer>> res = new HashMap<>();
                 List<Integer> lines = new ArrayList<>();
-                lines.add(12);
-                //lines.add(14);
+                //lines.add(12);      //source 1
+                lines.add(14);    //source 2
                 res.put("br.unb.cic.analysis.samples.ArrayDataFlowSample", lines);
                 return res;
             }
@@ -36,8 +36,8 @@ public class ArrayTaintedAnalysisOneConflictTest {
             protected Map<String, List<Integer>> sinkDefinitions() {
                 Map<String, List<Integer>> res = new HashMap<>();
                 List<Integer> lines = new ArrayList<>();
-                lines.add(19);
-                //lines.add(16);
+                lines.add(19);      //sink 1
+                lines.add(16);    //sink 2
                 res.put("br.unb.cic.analysis.samples.ArrayDataFlowSample", lines);
                 return res;
             }
@@ -53,11 +53,12 @@ public class ArrayTaintedAnalysisOneConflictTest {
         String cp = "target/test-classes";
         String targetClass = "br.unb.cic.analysis.samples.ArrayDataFlowSample";
 
+        PhaseOptions.v().setPhaseOption("jb", "use-original-names:true");
         SootWrapper.builder().withClassPath(cp).addClass(targetClass).build().execute();
     }
 
     @Test
     public void testDataFlowAnalysisExpectingOneConflict() {
-        Assert.assertEquals(1, analysis.getConflicts().size());
+        Assert.assertEquals(2, analysis.getConflicts().size());
     }
 }

--- a/src/test/java/br/unb/cic/analysis/samples/ArrayDataFlowSample.java
+++ b/src/test/java/br/unb/cic/analysis/samples/ArrayDataFlowSample.java
@@ -11,7 +11,7 @@ public class ArrayDataFlowSample {
 
         arr = populate(arr.length); //source 1
 
-        arr[4] = 10;    //source 2
+        arr[4] = 10;        //source 2
 
         int b = arr[4];     //sink 2
 


### PR DESCRIPTION
TaintedAnalysis now correctly detects conflicts with arrays.
Even when a single position of an array is tainted the entire array is marked as such.