### PR TITLE
Fix para erros de execução no Windows

### DIFF
--- a/src/main/java/br/unb/cic/analysis/cd/CDAnalysisSemanticConflicts.java
+++ b/src/main/java/br/unb/cic/analysis/cd/CDAnalysisSemanticConflicts.java
@@ -9,6 +9,7 @@ import scala.collection.JavaConverters;
 import soot.SootMethod;
 import soot.Unit;
 
+import java.io.File;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -59,12 +60,7 @@ public abstract class CDAnalysisSemanticConflicts extends JCD {
 
     @Override
     public final scala.collection.immutable.List<String> applicationClassPath() {
-        String[] array = new String[100];
-        if (cp.contains(":/") || cp.contains(":\\")){ // Windows class path error
-            array[0] = cp.toString();
-        }else{
-            array = cp.split(":");
-        }
+        String[] array = cp.split(File.pathSeparator);
         return JavaConverters.asScalaBuffer(Arrays.asList(array)).toList();
     }
 

--- a/src/main/java/br/unb/cic/analysis/dfp/DFPAnalysisSemanticConflicts.java
+++ b/src/main/java/br/unb/cic/analysis/dfp/DFPAnalysisSemanticConflicts.java
@@ -8,6 +8,7 @@ import scala.collection.JavaConverters;
 import soot.SootMethod;
 import soot.Unit;
 
+import java.io.File;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -66,12 +67,7 @@ public abstract class DFPAnalysisSemanticConflicts extends JDFP {
 
     @Override
     public final scala.collection.immutable.List<String> applicationClassPath() {
-        String[] array = new String[100];
-        if (cp.contains(":/") || cp.contains(":\\")){ // Windows class path error
-            array[0] = cp.toString();
-        }else{
-            array = cp.split(":");
-        }
+        String[] array = cp.split(File.pathSeparator);
         return JavaConverters.asScalaBuffer(Arrays.asList(array)).toList();
     }
 

--- a/src/main/java/br/unb/cic/analysis/pdg/PDGAnalysisSemanticConflicts.java
+++ b/src/main/java/br/unb/cic/analysis/pdg/PDGAnalysisSemanticConflicts.java
@@ -7,6 +7,8 @@ import br.unb.cic.soot.graph.*;
 import scala.collection.JavaConverters;
 import soot.SootMethod;
 import soot.Unit;
+
+import java.io.File;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -57,12 +59,7 @@ public abstract class PDGAnalysisSemanticConflicts extends JPDG {
 
     @Override
     public final scala.collection.immutable.List<String> applicationClassPath() {
-        String[] array = new String[100];
-        if (cp.contains(":/") || cp.contains(":\\")){ // Windows class path error
-            array[0] = cp.toString();
-        }else{
-            array = cp.split(":");
-        }
+        String[] array = cp.split(File.pathSeparator);
         return JavaConverters.asScalaBuffer(Arrays.asList(array)).toList();
     }
 

--- a/src/main/java/br/unb/cic/analysis/svfa/SVFAAnalysis.java
+++ b/src/main/java/br/unb/cic/analysis/svfa/SVFAAnalysis.java
@@ -7,6 +7,8 @@ import br.unb.cic.soot.svfa.jimple.JSVFA;
 import scala.collection.JavaConverters;
 import soot.SootMethod;
 import soot.Unit;
+
+import java.io.File;
 import java.util.*;
 
 /**
@@ -57,7 +59,7 @@ public abstract class SVFAAnalysis extends JSVFA {
 
     @Override
     public final scala.collection.immutable.List<String> applicationClassPath() {
-        String[] array = cp.split(":");
+        String[] array = cp.split(File.pathSeparator);
         return JavaConverters.asScalaBuffer(Arrays.asList(array)).toList();
     }
 


### PR DESCRIPTION
# Problema
Ao configurar o soot antes da execução de cada análise, se executado no Windows, a opção `process_dir` não era definida corretamente.

# Motivo
A opção é definida a partir do retorno do método `applicationClassPath` de cada análise, que retornava um valor inválido apenas no Windows, devido aos diferentes separadores de paths.

# Solução
- Método applicationClassPath() ajustado para se adaptar ao OS correspondente.