### PR TITLE
Fix entrypoint methods signatures and add CF filters and JSON report

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "conflict-static-analysis",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "conflict-static-analysis",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/src/main/java/br/unb/cic/analysis/Main.java
+++ b/src/main/java/br/unb/cic/analysis/Main.java
@@ -658,22 +658,9 @@ public class Main {
 
         List<String> entrypointsList = new ArrayList<>();
         for (String element : elements) {
-            entrypointsList.add(extractMethodSignature(element));
+            entrypointsList.add(element);
         }
 
         return entrypointsList;
-    }
-
-    private String extractMethodSignature(String fullMethodSignature) {
-        int lastColonIndex = fullMethodSignature.lastIndexOf(':');
-        if (lastColonIndex != -1) {
-            String methodSignature = fullMethodSignature.substring(lastColonIndex + 1).trim();
-            if (methodSignature.endsWith(">")) {
-                methodSignature = methodSignature.substring(0, methodSignature.length() - 1);
-            }
-            return methodSignature;
-        } else {
-            return "";
-        }
     }
 }

--- a/src/main/java/br/unb/cic/analysis/Main.java
+++ b/src/main/java/br/unb/cic/analysis/Main.java
@@ -338,7 +338,7 @@ public class Main {
         SootWrapper.applyPackages();
 
         conflicts.addAll(overrideAssignment.getConflicts().stream().map(c -> c.toString()).collect(Collectors.toList()));
-        JSONconflicts.addAll(overrideAssignment.getConflicts().stream().map(c -> c.toJSON()).collect(Collectors.toList()));
+        JSONconflicts.addAll(overrideAssignment.getFilteredConflicts().stream().map(c -> c.toJSON()).collect(Collectors.toList()));
         saveExecutionTime("Time to perform OA " + (interprocedural ? "Inter" : "Intra"));
 
         int visitedMethods = overrideAssignment.getVisitedMethodsCount();

--- a/src/main/java/br/unb/cic/analysis/Main.java
+++ b/src/main/java/br/unb/cic/analysis/Main.java
@@ -36,6 +36,8 @@ import soot.Transform;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.*;
@@ -111,9 +113,10 @@ public class Main {
             return;
         }
 
+        // write results to out.txt
         System.out.println(" Number of conflicts: " + conflicts.size());
         final String out = "out.txt";
-        final FileWriter fw = new FileWriter(out);
+        final FileWriter fw = new FileWriter(out, true);
         conflicts.forEach(c -> {
             try {
                 fw.write(c + "\n\n");
@@ -124,18 +127,45 @@ public class Main {
         fw.close();
         System.out.println(" Results exported to " + out);
 
+        // write results to out.json
         final String outJSON = "out.json";
-        final FileWriter fwJSON = new FileWriter(outJSON);
-        fwJSON.write("[\n");
-        JSONconflicts.forEach(c -> {
-            try {
-                fwJSON.write(c);
-                fwJSON.write(JSONconflicts.indexOf(c) == JSONconflicts.size() - 1 ? "\n" : ",\n");
-            } catch (Exception e) {
-                System.out.println("error exporting the results " + e.getMessage());
+
+        // get the previous content
+        String prevContent;
+        try {
+            prevContent = new String(Files.readAllBytes(Paths.get(outJSON)));
+        }
+        catch (Exception e) {
+            prevContent = "[\n";
+            System.out.println("Error getting the previous content of the JSON file " + e.getMessage());
+        }
+        StringBuilder results = new StringBuilder(prevContent);
+
+        if (!JSONconflicts.isEmpty()) {
+            // remove the last character if it is a closing bracket
+            if (results.toString().trim().endsWith("]")) {
+                int idx = results.lastIndexOf("]");
+                results.replace(idx, idx + 1, ",\n");
             }
-        });
-        fwJSON.write("\n]");
+
+            // add the new content
+            JSONconflicts.forEach(c -> {
+                try {
+                    results.append(c);
+                    results.append(JSONconflicts.indexOf(c) == JSONconflicts.size() - 1 ? "\n" : ",\n");
+                } catch (Exception e) {
+                    System.out.println("error exporting the results " + e.getMessage());
+                }
+            });
+            results.append("\n]");
+        }
+
+        // write the new content
+        final FileWriter fwJSON = new FileWriter(outJSON);
+        String[] lines = results.toString().split("\n");
+        for (String line : lines) {
+            fwJSON.write(line + "\n");
+        }
         fwJSON.close();
         System.out.println(" JSON Results exported to " + outJSON);
 

--- a/src/main/java/br/unb/cic/analysis/Main.java
+++ b/src/main/java/br/unb/cic/analysis/Main.java
@@ -23,6 +23,7 @@ import br.unb.cic.analysis.reachability.ReachabilityAnalysis;
 import br.unb.cic.analysis.svfa.SVFAAnalysis;
 import br.unb.cic.analysis.svfa.SVFAInterProcedural;
 import br.unb.cic.analysis.svfa.SVFAIntraProcedural;
+import br.unb.cic.analysis.svfa.confluence.ConfluenceConflict;
 import br.unb.cic.analysis.svfa.confluence.DFPConfluenceAnalysis;
 import br.unb.cic.diffclass.DiffClass;
 import com.google.common.base.Stopwatch;
@@ -554,6 +555,10 @@ public class Main {
         conflicts.addAll(analysis.getConfluentConflicts()
                 .stream()
                 .map(p -> formatConflict(p.toString()))
+                .collect(Collectors.toList()));
+        JSONconflicts.addAll(analysis.getConfluentConflicts()
+                .stream()
+                .map(ConfluenceConflict::toJSON)
                 .collect(Collectors.toList()));
 
         System.out.println("CONFLICTS: "+conflicts.toString());

--- a/src/main/java/br/unb/cic/analysis/Main.java
+++ b/src/main/java/br/unb/cic/analysis/Main.java
@@ -552,11 +552,11 @@ public class Main {
 
         analysis.execute(false);
         System.out.println("Depth limit: "+analysis.getDepthLimit());
-        conflicts.addAll(analysis.getConfluentConflicts()
+        conflicts.addAll(analysis.getConfluentConflicts(false)
                 .stream()
                 .map(p -> formatConflict(p.toString()))
                 .collect(Collectors.toList()));
-        JSONconflicts.addAll(analysis.getConfluentConflicts()
+        JSONconflicts.addAll(analysis.getConfluentConflicts(true)
                 .stream()
                 .map(ConfluenceConflict::toJSON)
                 .collect(Collectors.toList()));

--- a/src/main/java/br/unb/cic/analysis/StatementsUtil.java
+++ b/src/main/java/br/unb/cic/analysis/StatementsUtil.java
@@ -58,12 +58,11 @@ public class StatementsUtil {
     /**
      * Configures and retrieves the entry points using the provided entrypoints list and all statements.
      *
-     * @param allStatements a list of all source and sink statements.
      * @return a Scala list of SootMethod representing the configured entry points.
      */
-    private scala.collection.immutable.List<SootMethod> getConfiguredEntryPoints(List<Statement> allStatements) throws NoSuchMethodException {
+    private scala.collection.immutable.List<SootMethod> getConfiguredEntryPoints() throws NoSuchMethodException {
         return JavaConverters.asScalaBuffer(
-                new ArrayList<>(this.definition.configureEntryPoints(this.entrypoints, allStatements))
+                new ArrayList<>(this.definition.configureEntryPoints(this.entrypoints))
         ).toList();
     }
 
@@ -77,7 +76,7 @@ public class StatementsUtil {
             return retrieveEntryPointsFromSource();
         } else {
             try {
-                return getConfiguredEntryPoints(allStatements);
+                return getConfiguredEntryPoints();
             } catch (NoSuchMethodException e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/br/unb/cic/analysis/oa/OverrideAssignment.java
+++ b/src/main/java/br/unb/cic/analysis/oa/OverrideAssignment.java
@@ -60,6 +60,10 @@ public abstract class OverrideAssignment extends SceneTransformer implements Abs
         return oaConflictReport.getConflicts();
     }
 
+    public Set<Conflict> getFilteredConflicts() {
+        return oaConflictReport.filterConflictsWithSameRoot(oaConflictReport.getConflicts());
+    }
+
     @Override
     protected void internalTransform(String s, Map<String, String> map) {
         long startTime = System.currentTimeMillis();

--- a/src/main/java/br/unb/cic/analysis/svfa/confluence/ConfluenceConflict.java
+++ b/src/main/java/br/unb/cic/analysis/svfa/confluence/ConfluenceConflict.java
@@ -1,5 +1,6 @@
 package br.unb.cic.analysis.svfa.confluence;
 
+import br.unb.cic.analysis.model.TraversedLine;
 import br.unb.cic.soot.graph.StatementNode;
 
 import java.util.List;
@@ -38,6 +39,78 @@ public class ConfluenceConflict {
         return "SOURCE=>BASE: "
                 + pathToString(sourceNodePath) + "\n" +
                 "SINK=>BASE: " + pathToString(sinkNodePath);
+    }
+
+    public String toJSON() {
+        return this.formatJSON("CONFLUENCE", "CF conflict");
+    }
+
+    protected String formatJSON(String type, String label) {
+        StatementNode sourceNode = sourceNodePath.get(0);
+        StatementNode sinkNode = sinkNodePath.get(0);
+        StatementNode baseNode = sourceNodePath.get(sourceNodePath.size() - 1);
+        return String.format(
+                "{" + "\n" +
+                        "\t" + "\"type\": \"%s\"," + "\n" +
+                        "\t" + "\"label\": \"%s\"," + "\n" +
+                        "\t" + "\"body\": {" + "\n" +
+                        "\t\t" + "\"description\": \"%s\"," + "\n" +
+                        "\t\t" + "\"interference\": [" + "\n" +
+                        "\t\t\t" + "{" + "\n" +
+                        "\t\t\t\t" + "\"type\": \"source1\"," + "\n" +
+                        "\t\t\t\t" + "\"branch\": \"L\"," + "\n" +
+                        "\t\t\t\t" + "\"text\": \"%s\"," + "\n" +
+                        "\t\t\t\t" + "\"location\": {" + "\n" +
+                        "\t\t\t\t\t" + "\"file\": \"\"," + "\n" +
+                        "\t\t\t\t\t" + "\"class\": \"%s\"," + "\n" +
+                        "\t\t\t\t\t" + "\"method\": \"%s\"," + "\n" +
+                        "\t\t\t\t\t" + "\"line\": %d" + "\n" +
+                        "\t\t\t\t" + "}," + "\n" +
+                        "\t\t\t\t" + "\"stackTrace\": [" + sinkNodePath.stream().map(this::nodeToJSON).collect(Collectors.joining(",")) + "]" + "\n" +
+                        "\t\t\t" + "}," + "\n" +
+                        "\t\t\t" + "{" + "\n" +
+                        "\t\t\t\t" + "\"type\": \"source2\"," + "\n" +
+                        "\t\t\t\t" + "\"branch\": \"R\"," + "\n" +
+                        "\t\t\t\t" + "\"text\": \"%s\"," + "\n" +
+                        "\t\t\t\t" + "\"location\": {" + "\n" +
+                        "\t\t\t\t\t" + "\"file\": \"\"," + "\n" +
+                        "\t\t\t\t\t" + "\"class\": \"%s\"," + "\n" +
+                        "\t\t\t\t\t" + "\"method\": \"%s\"," + "\n" +
+                        "\t\t\t\t\t" + "\"line\": %d" + "\n" +
+                        "\t\t\t\t" + "}," + "\n" +
+                        "\t\t\t\t" + "\"stackTrace\": [" + sourceNodePath.stream().map(this::nodeToJSON).collect(Collectors.joining(",")) + "]" + "\n" +
+                        "\t\t\t" + "}," + "\n" +
+                        "\t\t\t" + "{" + "\n" +
+                        "\t\t\t\t" + "\"type\": \"confluence\"," + "\n" +
+                        "\t\t\t\t" + "\"branch\": \"B\"," + "\n" +
+                        "\t\t\t\t" + "\"text\": \"%s\"," + "\n" +
+                        "\t\t\t\t" + "\"location\": {" + "\n" +
+                        "\t\t\t\t\t" + "\"file\": \"\"," + "\n" +
+                        "\t\t\t\t\t" + "\"class\": \"%s\"," + "\n" +
+                        "\t\t\t\t\t" + "\"method\": \"%s\"," + "\n" +
+                        "\t\t\t\t\t" + "\"line\": %d" + "\n" +
+                        "\t\t\t\t" + "}" + "\n" +
+//                        "\t\t\t\t" + "\"stackTrace\": []" + "\n" +
+                        "\t\t\t" + "}" + "\n" +
+                        "\t\t" + "]" + "\n" +
+                        "\t" + "}" + "\n" +
+                        "}",
+                type, label, this.toString().replaceAll("\n", " "),
+                sinkNode.value().sootUnit().toString().replaceAll("\"", "'"), sinkNode.value().className(), sinkNode.value().method(), sinkNode.value().line(),
+                sourceNode.value().sootUnit().toString().replaceAll("\"", "'"), sourceNode.value().className(), sourceNode.value().method(), sourceNode.value().line(),
+                baseNode.value().sootUnit().toString().replaceAll("\"", "'"), baseNode.value().className(), baseNode.value().method(), baseNode.value().line()
+        );
+    }
+
+    private String nodeToJSON(StatementNode node) {
+        return String.format(
+                "{" + "\n" +
+                    "\t" + "\"class\": \"%s\"," + "\n" +
+                    "\t" + "\"method\": \"%s\"," + "\n" +
+                    "\t" + "\"line\": %d" + "\n" +
+                "}",
+                node.value().className(), node.value().method(), node.value().line()
+        );
     }
 
     private String pathToString(List<StatementNode> nodePath) {

--- a/src/main/java/br/unb/cic/analysis/svfa/confluence/DFPConfluenceAnalysis.java
+++ b/src/main/java/br/unb/cic/analysis/svfa/confluence/DFPConfluenceAnalysis.java
@@ -232,6 +232,18 @@ public class DFPConfluenceAnalysis {
         return new DFPAnalysisSemanticConflicts(this.cp, this.definition, this.depthLimit, this.entrypoints) {
 
             /**
+             * As in this case we want to detect flows between sink and base, this methods defines isSource as all units
+             * that are initially defined as sink
+             */
+            @Override
+            protected boolean isSource(Unit unit) {
+                return definition.getSinkStatements()
+                        .stream()
+                        .map(stmt -> stmt.getUnit())
+                        .anyMatch(u -> u.equals(unit));
+            }
+
+            /**
              * As in this case we want to detect flows between sink and base, this methods defines isSink as all units
              * that are neither source nor sink and are inside a method body
              */

--- a/src/main/java/br/unb/cic/analysis/svfa/confluence/DFPConfluenceAnalysis.java
+++ b/src/main/java/br/unb/cic/analysis/svfa/confluence/DFPConfluenceAnalysis.java
@@ -57,27 +57,16 @@ public class DFPConfluenceAnalysis {
     
         List<ConfluenceConflict> conflicts = new ArrayList<>(this.confluentFlows);
 
-        List<StatementNode> subStack = findFirstSubStack(conflicts);
-        while (subStack != null){
-            ConfluenceConflict toRemove = null;
-            for (ConfluenceConflict conflict : conflicts) {
-                if (conflict.getSourceNodePath().equals(subStack)) {
-                    toRemove = conflict;
-                    break;
-                }
-            }
-
-            if (toRemove != null) {
-                conflicts.remove(toRemove);
-            }
-
-            subStack = findFirstSubStack(conflicts);
+        ConfluenceConflict toRemove = findFirstSubStack(conflicts);
+        while (toRemove != null) {
+            conflicts.remove(toRemove);
+            toRemove = findFirstSubStack(conflicts);
         }
 
         return new HashSet<>(conflicts);
     }
     
-    private List<StatementNode> findFirstSubStack(List<ConfluenceConflict> conflicts) {
+    private ConfluenceConflict findFirstSubStack(List<ConfluenceConflict> conflicts) {
 
         for (int i = 0; i < conflicts.size(); i++){
             ConfluenceConflict conflictA = conflicts.get(i);
@@ -113,7 +102,7 @@ public class DFPConfluenceAnalysis {
                             break;
                         }
                     }
-                    if (match) return pathA;
+                    if (match) return conflictA;
                 }
             }
         }

--- a/src/main/java/br/unb/cic/analysis/svfa/confluence/DFPConfluenceAnalysis.java
+++ b/src/main/java/br/unb/cic/analysis/svfa/confluence/DFPConfluenceAnalysis.java
@@ -50,9 +50,83 @@ public class DFPConfluenceAnalysis {
      *
      * @return a set of confluence conflicts
      */
-    public Set<ConfluenceConflict> getConfluentConflicts() {
-        return this.confluentFlows;
+    public Set<ConfluenceConflict> getConfluentConflicts(boolean filterDuplicates) {
+        if (!filterDuplicates) {
+            return this.confluentFlows;
+        }
+    
+        List<ConfluenceConflict> conflicts = new ArrayList<>(this.confluentFlows);
+
+        List<StatementNode> subStack = findFirstSubStack(conflicts);
+        while (subStack != null){
+            ConfluenceConflict toRemove = null;
+            for (ConfluenceConflict conflict : conflicts) {
+                if (conflict.getSourceNodePath().equals(subStack)) {
+                    toRemove = conflict;
+                    break;
+                }
+            }
+
+            if (toRemove != null) {
+                System.out.println("CONFLITO REMOVIDO");
+                System.out.println(toRemove);
+                conflicts.remove(toRemove);
+            }
+
+            subStack = findFirstSubStack(conflicts);
+        }
+
+        return new HashSet<>(conflicts);
     }
+    
+    private List<StatementNode> findFirstSubStack(List<ConfluenceConflict> conflicts) {
+
+        for (int i = 0; i < conflicts.size(); i++){
+            ConfluenceConflict conflictA = conflicts.get(i);
+            List<StatementNode> pathA = conflictA.getSourceNodePath();
+            StatementNode confluenceA = pathA.get(pathA.size() - 1); 
+
+            for (int j = 0; j < conflicts.size(); j++) {
+                if (i == j) continue;
+    
+                ConfluenceConflict conflictB = conflicts.get(j);
+                List<StatementNode> pathB = conflictB.getSourceNodePath();
+                StatementNode confluenceB = pathB.get(pathB.size() - 1);
+    
+                if (!confluenceA.value().className().equals(confluenceB.value().className()) ||
+                    confluenceA.value().line() != confluenceB.value().line()) {
+                    System.out.println("Linha do conflueceA");
+                    System.out.println(confluenceA.value().line());
+                    System.out.println("QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ");
+                    System.out.println("Linha do conflueceB");
+                    System.out.println(confluenceB.value().line());
+                    continue;
+                }
+                
+                if (pathA.size() > pathB.size()){
+                    continue;
+                }
+
+                for (int z = 0; z <= pathB.size() - pathA.size(); z++) {
+                    boolean match = true;
+                    for (int y = 0; y < pathA.size(); y++) {
+                        StatementNode s = pathA.get(y);
+                        StatementNode b = pathB.get(z + y);
+            
+                        if (!s.value().className().equals(b.value().className()) ||
+                            !s.value().method().equals(b.value().method()) ||
+                            s.value().line() != b.value().line()) {
+                            match = false;
+                            break;
+                        }
+                    }
+                    if (match) return pathA;
+                }
+            }
+        }
+        return null;
+    }
+    
 
     /**
      * Executes both source -> base and sink -> base SVFA analysis intersects then populating

--- a/src/main/java/br/unb/cic/analysis/svfa/confluence/DFPConfluenceAnalysis.java
+++ b/src/main/java/br/unb/cic/analysis/svfa/confluence/DFPConfluenceAnalysis.java
@@ -182,7 +182,9 @@ public class DFPConfluenceAnalysis {
 
     public StatementNode containsKey(Map<StatementNode, List<StatementNode>> pathEndHash, StatementNode lastNode){
         for (StatementNode stmt: pathEndHash.keySet()){
-            if (lastNode.equals(stmt)) {
+            if (lastNode.value().line() == stmt.value().line() &&
+                    lastNode.value().method().equals(stmt.value().method()) &&
+                    lastNode.value().className().equals(stmt.value().className())) {
                 return stmt;
             }
         }

--- a/src/main/java/br/unb/cic/analysis/svfa/confluence/DFPConfluenceAnalysis.java
+++ b/src/main/java/br/unb/cic/analysis/svfa/confluence/DFPConfluenceAnalysis.java
@@ -68,8 +68,6 @@ public class DFPConfluenceAnalysis {
             }
 
             if (toRemove != null) {
-                System.out.println("CONFLITO REMOVIDO");
-                System.out.println(toRemove);
                 conflicts.remove(toRemove);
             }
 
@@ -95,11 +93,6 @@ public class DFPConfluenceAnalysis {
     
                 if (!confluenceA.value().className().equals(confluenceB.value().className()) ||
                     confluenceA.value().line() != confluenceB.value().line()) {
-                    System.out.println("Linha do conflueceA");
-                    System.out.println(confluenceA.value().line());
-                    System.out.println("QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ");
-                    System.out.println("Linha do conflueceB");
-                    System.out.println(confluenceB.value().line());
                     continue;
                 }
                 


### PR DESCRIPTION
## ⚠️ Problems:
1. The analysis were serching the entrypoints methods classes in the wrong place, causing "method not found" errors
2. Each analysis executed was overriding the previous analysis results on the output files
3. CF analysis was executing the same inner DF twice (considering only right to base paths), causing false positives
4. CF sometimes could report less conflicts if multiple paths that ended in the same line were found

## 🔧 Fixes:
- [X] Passing the full methods signatures (wich contains its class) to the entrypoints processing solved the 1st issue
- [X] Appending results instead of writing solved the 2nd issue
- [X] Redefinining the second DF to search for left to base paths solved the 3rd issue
- [X] Changing the condition that checks whether paths end on the same line seems to have solved the 4th issue

## ✨ Additions:
- OA analysis now filters conflicts with the same reported lines (only on JSON output)
- CF analysis now generates a JSON output
- CF analysis now filters duplicated reports