### PR TITLE
Updating maven's binaries link

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ ARG USER_HOME_DIR="/root"
 ARG SHA=b4880fb7a3d81edd190a029440cdf17f308621af68475a4fe976296e71ff4a4b546dd6d8a58aaafba334d309cc11e638c52808a4b0e818fc0fd544226d952544
 
 ## 4- Define the URL where maven can be downloaded from
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+ARG BASE_URL=https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ## 5- Create the directories, download maven, validate the download, install it, remove downloaded file and set links
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref && \


### PR DESCRIPTION
This pull request has the purpose of updating the maven's binaries link. This is necessary because the current [maven's download page](https://maven.apache.org/download.cgi) is different when compared to the one in the dockerfile. I faced an issue when trying to build this image due to the wrong link being present in dockerfile.